### PR TITLE
Devel

### DIFF
--- a/autosync-xdg-launcher.sh
+++ b/autosync-xdg-launcher.sh
@@ -7,5 +7,5 @@ mkdir -p $data/log
 for i in $conf/*
 do
     pkill -f "python.*autosync.py .*autosync/$(basename $i)"
-    autosync.py $i &> $data/log/$(basename $i).$(date '+%F-%T').log &
+    dvcs-autosync $i &> $data/log/$(basename $i).$(date '+%F-%T').log &
 done


### PR DESCRIPTION
bugfix: autosync-xdg-launcher.sh should launch dvcs-autosync, not autosync.py
